### PR TITLE
Typo fix

### DIFF
--- a/libs/angles.js
+++ b/libs/angles.js
@@ -116,7 +116,7 @@ angles.directive("donutchart", function () {
 			var ctx = $elem[0].getContext("2d");
 			var chart = new Chart(ctx);
 			$scope.$watch("data", function (newVal, oldVal) { 
-				chart.Donut($scope.data, $scope.options);
+				chart.Doughnut($scope.data, $scope.options);
 			}, true);
 		}
 	}


### PR DESCRIPTION
I'm using this wrapper on the dashboard for a project I'm working on. Just noticed this typo for the Doughnut charts.
