### PR TITLE
Exit if data are not defined

### DIFF
--- a/libs/angles.js
+++ b/libs/angles.js
@@ -14,6 +14,9 @@ angles.chart = function (type) {
 			var chart = new Chart(ctx);
 			
 			$scope.$watch("data", function (newVal, oldVal) { 
+				// if data not defined, exit
+				if (!newVal) return;
+				
 				chart[type]($scope.data, $scope.options);
 			}, true);
 		}


### PR DESCRIPTION
If I use an async call to get my data, the chart is drawn before the data comes in, so I get an error in the console.
