### PR TITLE
Allow AJAX charts

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -65,8 +65,10 @@ angles.directive("chart", function () {
 
 			var chart = new Chart(ctx);
 			
-			$scope.$watch("data", function (newVal, oldVal) { 
-				chart[$scope.type]($scope.data, $scope.options);
+			$scope.$watch("data", function (newVal, oldVal) {
+				if ($scope.data !== undefined) { 
+				  chart[$scope.type]($scope.data, $scope.options);
+				}
 			}, true);
 		}
 	} 


### PR DESCRIPTION
Sometimes (usually IMHO) the chart's data isn't present during initialization.
In this case the code throws an exception bcz $scope.data is not defined when calling chart[$scope.type]($scope.data, $scope.options);

I added a simple if statement to resolve this issue. You can now define a chart and then fetch its data using AJAX...
