### PR TITLE
Added "resize" directive

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -2,77 +2,103 @@ var angles = angular.module("angles", []);
 
 
 angles.chart = function (type) {
-	return { 
-		restrict: "A",
-		scope: {
-			data: "=",
-			options: "=",
-			id: "@",
-			width: "=",
-			height: "="
-		},
-		link: function ($scope, $elem) {
-			var ctx = $elem[0].getContext("2d");
+    return { 
+        restrict: "A",
+        scope: {
+            data: "=",
+            options: "=",
+            id: "@",
+            width: "=",
+            height: "="
+        },
+        link: function ($scope, $elem) {
+            var ctx = $elem[0].getContext("2d");
+            var autosize = false
 
-			if ($scope.width <= 0) {
-				$elem.width($elem.parent().width());
-				$elem.height($elem.parent().height());
-				ctx.canvas.width = $elem.width();
-				ctx.canvas.height = ctx.canvas.width / 2;				
-			} else {
-				ctx.canvas.width = $scope.width || ctx.canvas.width;
-				ctx.canvas.height = $scope.height || ctx.canvas.height;
-			}
+            if ($scope.width <= 0) {
+                $elem.width($elem.parent().width());
+                $elem.height($elem.parent().height());
+                ctx.canvas.width = $elem.width();
+                ctx.canvas.height = ctx.canvas.width / 2;               
+            } else {
+                ctx.canvas.width = $scope.width || ctx.canvas.width;
+                ctx.canvas.height = $scope.height || ctx.canvas.height;
+                autosize = true;
+            }
 
-	
-			var chart = new Chart(ctx);
+    
+            var chart = new Chart(ctx);
 
-			$scope.$watch("data", function (newVal, oldVal) { 
-				// if data not defined, exit
-				if (!newVal) return;
-				
-				chart[type]($scope.data, $scope.options);
-			}, true);
-		}
-	}
+            $scope.$watch("data", function (newVal, oldVal) { 
+                // if data not defined, exit
+                if(autosize){
+                    ctx.canvas.width = $scope.width || $elem.parent().width();
+                    ctx.canvas.height = $scope.height || $elem.parent().height();
+                    chart = new Chart(ctx);
+                } else if (!newVal) return;
+                
+                chart[type]($scope.data, $scope.options);
+            }, true);
+        }
+    }
 }
 
 
 /* General Chart Wrapper */
 angles.directive("chart", function () { 
-	return { 
-		restrict: "A",
-		scope: {
-			data: "=",
-			type: "@",
-			options: "=",
-			id: "@",
-			width: "=",
-			height: "="
-		},
-		link: function ($scope, $elem) {
-			var ctx = $elem[0].getContext("2d");
+    return { 
+        restrict: "A",
+        scope: {
+            data: "=",
+            type: "@",
+            options: "=",
+            id: "@",
+            width: "=",
+            height: "="
+        },
+        link: function ($scope, $elem) {
+            var ctx = $elem[0].getContext("2d");
+            var autosize = false
 
-			if ($scope.width <= 0) {
-				$elem.width($elem.parent().width());
-				$elem.height($elem.parent().height());
-				ctx.canvas.width = $elem.width();
-				ctx.canvas.height = ctx.canvas.width / 2;				
-			} else {
-				ctx.canvas.width = $scope.width || ctx.canvas.width;
-				ctx.canvas.height = $scope.height || ctx.canvas.height;
-			}
+            if ($scope.width <= 0) {
+                $elem.width($elem.parent().width());
+                $elem.height($elem.parent().height());
+                ctx.canvas.width = $elem.width();
+                ctx.canvas.height = ctx.canvas.width / 2;               
+            } else {
+                ctx.canvas.width = $scope.width || $elem.parent().width();
+                ctx.canvas.height = $scope.height || $elem.parent().height();
+                autosize = true;
+            }
 
-			var chart = new Chart(ctx);
-			
-			$scope.$watch("data", function (newVal, oldVal) {
-				if ($scope.data !== undefined) { 
-				  chart[$scope.type]($scope.data, $scope.options);
-				}
-			}, true);
-		}
-	} 
+
+            var chart = new Chart(ctx);
+
+            $scope.$watch("data", function (newVal, oldVal) {
+                if(autosize){
+                    ctx.canvas.width = $scope.width || $elem.parent().width();
+                    ctx.canvas.height = $scope.height || $elem.parent().height();
+                    chart = new Chart(ctx);
+                }
+
+                if ($scope.data !== undefined) { 
+                  chart[$scope.type]($scope.data, $scope.options);
+                }
+            }, true);
+        }
+    } 
 });
+
+angles.directive('resize', function ($window) {
+    return function ($scope, $elem) {
+        var w = angular.element($window);
+
+        w.bind('resize', function () {
+            $scope.plotData["refresh"] = !$scope.plotData["refresh"];
+            $scope.$apply();
+        });
+    }
+})
 
 
 /* Aliases for various chart types */


### PR DESCRIPTION
When the "resize" directive is added on the same element as the chart, resizing the window will trigger a repaint, toggling a dummy value in the scope: "refresh".

This is specially useful when using media queries on the CSS, such as with Bootstrap.
