### PR TITLE
Fix issue #34

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -51,7 +51,12 @@ angles.chart = function (type) {
 		            $scope.size();
 		            chart = new Chart(ctx);
 		            chart[type]($scope.data, $scope.options);
-		        });	            
+		        });	  
+                
+                //unbind the event when scope destroyed 
+                $scope.$on("$destroy", function() {
+                     angular.element(window).off();
+                });                           
             }
             
 			$scope.size();


### PR DESCRIPTION
add code to unbind the 'resize' event. if not unbind, the window would be
binded the event twice  when we back to the view which contains the
angles, and then the browser become unresponsive
