### PR TITLE
Angular Routing Fix

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -1,7 +1,7 @@
 var angles = angular.module("angles", []);
 
 angles.chart = function (type) {
-    return { 
+    return {
         restrict: "A",
         scope: {
             data: "=",
@@ -16,57 +16,57 @@ angles.chart = function (type) {
             var ctx = $elem[0].getContext("2d");
             var autosize = false;
 
-			$scope.size = function () {
-	            if ($scope.width <= 0) {
-	                $elem.width($elem.parent().width());
-	                ctx.canvas.width = $elem.width();
-	            } else {
-	                ctx.canvas.width = $scope.width || ctx.canvas.width;
-	                autosize = true;
-	            }				
+            $scope.size = function () {
+                if ($scope.width <= 0) {
+                    $elem.width($elem.parent().width());
+                    ctx.canvas.width = $elem.width();
+                } else {
+                    ctx.canvas.width = $scope.width || ctx.canvas.width;
+                    autosize = true;
+                }
 
-                if($scope.height <= 0){
+                if ($scope.height <= 0) {
                     $elem.height($elem.parent().height());
-                    ctx.canvas.height = ctx.canvas.width / 2;   
+                    ctx.canvas.height = ctx.canvas.width / 2;
                 } else {
                     ctx.canvas.height = $scope.height || ctx.canvas.height;
                     autosize = true;
                 }
-			}
+            };
 
-            $scope.$watch("data", function (newVal, oldVal) { 
+            $scope.$watch("data", function (newVal, oldVal) {
                 // if data not defined, exit
                 if (!newVal) {
-                  return;
+                    return;
                 }
                 if ($scope.chart) { type = $scope.chart; }
-                
-                if(autosize){
+
+                if (autosize) {
                     $scope.size();
                     chart = new Chart(ctx);
                 } else if (!newVal) return;
-                
+
                 chart[type]($scope.data, $scope.options);
             }, true);
-            
+
             if ($scope.resize) {
-		        angular.element(window).on('resize', function () {
-		            $scope.size();
-		            chart = new Chart(ctx);
-		            chart[type]($scope.data, $scope.options);
-		        });	  
-                
-                //unbind the event when scope destroyed 
-                $scope.$on("$destroy", function() {
-                     angular.element(window).off('resize');
-                });                           
+                angular.element(window).on('resize', function () {
+                    $scope.size();
+                    chart = new Chart(ctx);
+                    chart[type]($scope.data, $scope.options);
+                });
+
+                //unbind the event when scope destroyed
+                $scope.$on("$destroy", function () {
+                    angular.element(window).off('resize');
+                });
             }
-            
-			$scope.size();
+
+            $scope.size();
             var chart = new Chart(ctx);
         }
     }
-}
+};
 
 
 /* Aliases for various chart types */


### PR DESCRIPTION
The following code was recently merged into the master branch. 

``` javascript
//unbind the event when scope destroyed 
$scope.$on("$destroy", function() {
     angular.element(window).off();
});                           
```

Calling `off()` without any event types on the window element will de-register ALL event listeners on the `window` object. This has the side-effect of removing the listeners that ngRoute uses to listen for page change events (ie. those as generated by the browser Back/Forward buttons). This breaks the usage of back/forward buttons in Angular.

This changes this deregistration to the below so that only 'resize' listeners are removed. 

``` javascript
//unbind the event when scope destroyed 
$scope.$on("$destroy", function() {
     angular.element(window).off('resize');
});                           
```

This pull request also includes a commit that makes some style consistency changes. Previously, there was inconsistent whitespace and a couple missing semicolons. If you would prefer to keep the styling as-is, I can remove that commit.
