### PR TITLE
Add main setting to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
   "authors": [
     "Lindsay Silver"
   ],
+  "main": "angles.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
[Debowerify](https://github.com/eugeneware/debowerify) requires a 'main' property in the bower.json, which then allows you to use normal bower packages with browserify.
