### PR TITLE
Fixed 'chartCreated is undefined' error

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -65,8 +65,9 @@ angles.chart = function (type) {
                     angular.element($elem[0]).parent().after( chartCreated.generateLegend() );
             }, true);
 
-            $scope.$watch("tooltip", function (newVal, oldVal){
-                chartCreated.draw();
+            $scope.$watch("tooltip", function (newVal, oldVal) {
+                if (chartCreated)
+                    chartCreated.draw();
                 if(newVal===undefined || !chartCreated.segments)
                     return;
                 if(!isFinite(newVal) || newVal >= chartCreated.segments.length || newVal < 0)


### PR DESCRIPTION
When data for the chart is not immediately available, e.g. it is coming
from a JSON request, an error is thrown because chartCreated does not
exist on the initial call to $scope.$watch("tooltip"

Closes #53 
