### PR TITLE
Fixed issue with "chart" directive and "type" attribute throwing an exception and not reading in chart type

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -10,7 +10,7 @@ angles.chart = function (type) {
             width: "=",
             height: "=",
             resize: "=",
-            chart: "@",
+            type: "@",
             segments: "@",
             responsive: "=",
             tooltip: "=",
@@ -46,7 +46,7 @@ angles.chart = function (type) {
                 if (!newVal) {
                     return;
                 }
-                if ($scope.chart) { type = $scope.chart; }
+                if ($scope.type) { type = $scope.type; }
                 
                 if(autosize){
                     $scope.size();


### PR DESCRIPTION
Originally, using the general `chart` directive (as opposed to a specific directive such as `linechart` or `barchart`), and the described `type` attribute caused an exception to be thrown (`TypeError: undefined is not a function`), and stopped the chart from being rendered at all. This was due to the fact that there was no `type` attribute defined in the directive's isolated scope. Looking at the code, it seemed as if though the chart type was expected to be specified in an attribute `chart` (which is currently also a directive name), not an attribute `type`. This `chart` attribute bound to the directive's isolated scope was changed to `type`, and it no longer causes an exception to be thrown and allows the charts to be rendered as expected.

See issue #52 for the original reported issue.
