### PR TITLE
Update angles.js

### DIFF
--- a/angles.js
+++ b/angles.js
@@ -41,6 +41,8 @@ angles.chart = function (type) {
             $scope.$watch("data", function (newVal, oldVal) {
                 if(chartCreated)
                     chartCreated.destroy();
+                   
+                $scope.options = {};
                     
                 // if data not defined, exit
                 if (!newVal) {


### PR DESCRIPTION
without this fix we have errors inside "if($scope.responsive || $scope.resize)" because uninitialised variable
