### PR TITLE
Update bower.json - change chart.js 1.0.1-beta.3 to 1.0.1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,6 +17,6 @@
     "libs/Chart.js"
   ],
   "dependencies": {
-    "chartjs": "1.0.1-beta.3"
+    "chartjs": "1.0.1"
   }
 }


### PR DESCRIPTION
A'm allready use angles 1.0.1-beta with Chart.js 1.0.1 and I haven't got any problems with it.
Is it any reason to use Chart.js 1.0.1-beta.3? If it's no reason, let's update dependencies.